### PR TITLE
fix(rtl): isolate slider direction from host page so Slick carousel w…

### DIFF
--- a/includes/class-slider-deserializer.php
+++ b/includes/class-slider-deserializer.php
@@ -43,6 +43,7 @@ class Slider_Deserializer {
             $styles[] = 'all';
             $styles[] = 'url';
             $styles[] = 'float';
+            $styles[] = 'direction';
             return $styles;
         });
 

--- a/includes/reviews-slider-horizontal-carousel-template.php
+++ b/includes/reviews-slider-horizontal-carousel-template.php
@@ -7,7 +7,7 @@ if (!isset($opio_translator)) { $opio_translator = null; }
 
 ?>
 <!-- reviews-slider-horizontal-carousel-template.php -->
-<div id="opio-carousel-widget">
+<div id="opio-carousel-widget" style="direction: ltr;">
 <?php 
     $review_feed_link = '#';
     if(isset($feed_object->review_feed_link)) {

--- a/includes/reviews-slider-horizontal-template.php
+++ b/includes/reviews-slider-horizontal-template.php
@@ -8,7 +8,7 @@ if (!isset($opio_translator)) { $opio_translator = null; }
 ?>
 <!-- reviews-slider-horizontal-template.php -->
 
-<div id="opio-horizontal-widget">
+<div id="opio-horizontal-widget" style="direction: ltr;">
 
 <?php 
 

--- a/includes/reviews-slider-vertical-template.php
+++ b/includes/reviews-slider-vertical-template.php
@@ -7,7 +7,7 @@ if (!isset($opio_translator)) { $opio_translator = null; }
 
 ?>
 <!-- reviews-slider-vertical-template.php -->
-<div id="opio-vertical-widget">
+<div id="opio-vertical-widget" style="direction: ltr;">
 
 <?php 
     $review_feed_link = '#';

--- a/opio.php
+++ b/opio.php
@@ -3,7 +3,7 @@
 Plugin Name: Widget for OPIO Reviews
 Plugin URI: 
 Description: Instantly add OPIO Reviews on your website to increase user confidence and SEO.
-Version: 1.1.20
+Version: 1.1.21
 Author: Dhiraj Timalsina <dhiraj@n49.com>
 Text Domain: widget-for-opio-reviews
 Domain Path: /languages
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 
 require(ABSPATH . 'wp-includes/version.php');
 
-define('OPIO_PLUGIN_VERSION'   , '1.1.20');
+define('OPIO_PLUGIN_VERSION'   , '1.1.21');
 define('OPIO_PLUGIN_FILE'      , __FILE__);
 define('OPIO_PLUGIN_URL'       , plugins_url(basename(plugin_dir_path(__FILE__ )), basename(__FILE__)));
 define('OPIO_ASSETS_URL'       , OPIO_PLUGIN_URL . '/assets/');

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Author: Dhiraj Timalsina
 Tags: Widget for OPIO Reviews, opio, reviews, rating, widget, google business, testimonials
 Tested up to: 6.4
-Stable tag: 1.1.20
+Stable tag: 1.1.21
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -85,6 +85,9 @@ Any other ISO 639-1 code (e.g., `sw`, `nb`, `fi`, `cs`) will translate review co
 Full developer documentation, filter hooks for raising translation quota, and instructions for adding a 31st hand-curated language are in `LANGUAGES.md` in the plugin folder.
 
 == Changelog ==
+
+= 1.1.21 =
+* Fix: slider tiles invisible on RTL host pages (Arabic / Persian / Urdu / Hebrew). The slider's outer wrapper now declares `direction: ltr` so page-level RTL inheritance doesn't break Slick carousel's internal positioning math. Arabic/Persian/Urdu/Hebrew text inside tiles still renders right-to-left via Unicode bidi.
 
 = 1.1.20 =
 * Docs: Mark which 4 of the 30 supported languages are right-to-left (`ar`, `fa`, `ur`, `he`) in `LANGUAGES.md`, `readme.txt`, and the in-admin Support tab.


### PR DESCRIPTION
…orks on RTL sites (v1.1.21)

When the host page declares dir="rtl" (e.g. Polylang Arabic URL), CSS direction inheritance reaches our slider container and Slick carousel's transform math silently pushes tiles off-screen — slider appears empty even though the DOM contains all tiles. The widget controls (Powered by / See all / Write a review) also end up on the wrong side because flex order flips under RTL.

Fix: emit `style="direction: ltr;"` on each layout's outer wrapper. Allowlist `direction` in safe_style_css so wp_kses doesn't strip it.

The slider's visual layout now stays identical across all language URLs. Arabic/Persian/Urdu/Hebrew text content INSIDE each tile still renders right -to-left automatically (Unicode bidi handles glyph direction at the character level regardless of the container's direction).