### PR TITLE
add translation telemetry for production debugging (v1.1.22)

### DIFF
--- a/includes/class-slider-shortcode.php
+++ b/includes/class-slider-shortcode.php
@@ -65,6 +65,7 @@ class Slider_Shortcode {
 		ob_start();
 
         $debug = array(
+            'plugin_version'           => defined('OPIO_PLUGIN_VERSION') ? OPIO_PLUGIN_VERSION : '',
             'lang_attr'                => (string) $lang_attr,
             'target_locale'            => (string) $target_locale,
             'opio_target_lang'         => (string) $opio_target_lang,
@@ -74,6 +75,7 @@ class Slider_Shortcode {
             'js_translations_count'    => count($js_translations),
             'plugin_textdomain_loaded' => is_textdomain_loaded('widget-for-opio-reviews'),
             'read_more_translated'     => __('Read more', 'widget-for-opio-reviews'),
+            'translation_stats'        => $opio_translator ? $opio_translator->get_stats() : null,
         );
         echo '<script type="text/javascript" id="opio-slider-debug">console.log("[OPIO slider]", ' . wp_json_encode($debug) . ');</script>';
 
@@ -89,6 +91,15 @@ class Slider_Shortcode {
             include_once 'reviews-slider-vertical-template.php';
         }
         ob_get_contents();
+
+        // Post-render stats — counters were populated during template execution above.
+        if ($opio_translator) {
+            $post_stats = array(
+                'translation_stats' => $opio_translator->get_stats(),
+                'render_phase'      => 'post',
+            );
+            echo '<script type="text/javascript" id="opio-slider-debug-post">console.log("[OPIO slider stats]", ' . wp_json_encode($post_stats) . ');</script>';
+        }
 
         $output = ob_get_clean(); // Capture the entire output of the function
 

--- a/includes/class-slider-translator.php
+++ b/includes/class-slider-translator.php
@@ -8,6 +8,31 @@ class Slider_Translator {
     const TRANSIENT_TTL    = 2592000; // 30 days
     const REQUEST_TIMEOUT  = 5;
 
+    private $stats = array(
+        'translation_calls'   => 0,
+        'cache_full_hits'     => 0,
+        'chunks_total'        => 0,
+        'chunk_cache_hits'    => 0,
+        'api_calls'           => 0,
+        'api_success'         => 0,
+        'api_errors'          => 0,
+        'last_error'          => null,
+        'last_http_code'      => null,
+        'last_endpoint_host'  => null,
+        'schema_fetched'      => false,
+        'schema_fetch_success'=> false,
+        'schema_translated'   => false,
+    );
+
+    public function get_stats() {
+        return $this->stats;
+    }
+
+    private function record_error($message) {
+        $this->stats['api_errors']++;
+        $this->stats['last_error'] = is_string($message) ? substr($message, 0, 200) : 'unknown_error';
+    }
+
     private static $locale_map = array(
         'en' => 'en_US',
         'fr' => 'fr_CA',
@@ -126,13 +151,17 @@ class Slider_Translator {
             return $text;
         }
 
+        $this->stats['translation_calls']++;
+
         $cache_key = self::TRANSIENT_PREFIX . md5($text . '|' . $target_lang_code);
         $cached    = get_transient($cache_key);
         if ($cached !== false) {
+            $this->stats['cache_full_hits']++;
             return $cached;
         }
 
         $chunks = $this->chunk_text($text, self::CHUNK_MAX_LEN);
+        $this->stats['chunks_total'] += count($chunks);
         $translated_chunks = array();
         foreach ($chunks as $chunk) {
             $translated = $this->translate_chunk($chunk, $target_lang_code);
@@ -151,11 +180,13 @@ class Slider_Translator {
         $chunk_key = self::TRANSIENT_PREFIX . 'c_' . md5($text . '|' . $target_lang_code);
         $cached    = get_transient($chunk_key);
         if ($cached !== false) {
+            $this->stats['chunk_cache_hits']++;
             return $cached;
         }
 
         $endpoint = apply_filters('opio_translation_endpoint', 'https://api.mymemory.translated.net/get');
         $email    = apply_filters('opio_translation_email', '');
+        $this->stats['last_endpoint_host'] = parse_url($endpoint, PHP_URL_HOST);
 
         $query = array(
             'q'        => $text,
@@ -165,23 +196,33 @@ class Slider_Translator {
             $query['de'] = $email;
         }
 
+        $this->stats['api_calls']++;
+
         $response = wp_remote_get(add_query_arg($query, $endpoint), array(
             'timeout' => self::REQUEST_TIMEOUT,
         ));
 
         if (is_wp_error($response)) {
-            error_log('[OPIO slider] translation request error: ' . $response->get_error_message());
+            $err = 'wp_error: ' . $response->get_error_message();
+            $this->record_error($err);
+            error_log('[OPIO slider] translation request error (lang=' . $target_lang_code . ', host=' . $this->stats['last_endpoint_host'] . '): ' . $response->get_error_message());
             return false;
         }
-        if (wp_remote_retrieve_response_code($response) !== 200) {
-            error_log('[OPIO slider] translation HTTP ' . wp_remote_retrieve_response_code($response));
+
+        $http_code = wp_remote_retrieve_response_code($response);
+        $this->stats['last_http_code'] = $http_code;
+
+        if ($http_code !== 200) {
+            $this->record_error('http_' . $http_code);
+            error_log('[OPIO slider] translation HTTP ' . $http_code . ' (lang=' . $target_lang_code . ', host=' . $this->stats['last_endpoint_host'] . ')');
             return false;
         }
 
         $body    = wp_remote_retrieve_body($response);
         $decoded = json_decode($body, true);
         if (!is_array($decoded) || empty($decoded['responseData']['translatedText']) || !is_string($decoded['responseData']['translatedText'])) {
-            error_log('[OPIO slider] translation response unexpected: ' . substr($body, 0, 200));
+            $this->record_error('unexpected_response: ' . substr($body, 0, 100));
+            error_log('[OPIO slider] translation response unexpected (lang=' . $target_lang_code . '): ' . substr($body, 0, 200));
             return false;
         }
 
@@ -189,10 +230,12 @@ class Slider_Translator {
         if (stripos($translated, 'QUERY LENGTH LIMIT EXCEEDED') !== false
             || stripos($translated, 'MYMEMORY WARNING') !== false
             || stripos($translated, 'INVALID LANGUAGE PAIR') !== false) {
-            error_log('[OPIO slider] translation API warning: ' . $translated);
+            $this->record_error('api_warning: ' . substr($translated, 0, 100));
+            error_log('[OPIO slider] translation API warning (lang=' . $target_lang_code . '): ' . $translated);
             return false;
         }
 
+        $this->stats['api_success']++;
         set_transient($chunk_key, $translated, self::TRANSIENT_TTL);
         return $translated;
     }
@@ -277,8 +320,15 @@ class Slider_Translator {
             $schema_url .= '&type=local';
         }
 
+        $this->stats['schema_fetched'] = true;
         $response = wp_remote_get($schema_url, array('timeout' => self::REQUEST_TIMEOUT));
-        if (is_wp_error($response) || wp_remote_retrieve_response_code($response) !== 200) {
+        if (is_wp_error($response)) {
+            error_log('[OPIO slider] schema fetch error: ' . $response->get_error_message());
+            return null;
+        }
+        $http_code = wp_remote_retrieve_response_code($response);
+        if ($http_code !== 200) {
+            error_log('[OPIO slider] schema fetch HTTP ' . $http_code);
             return null;
         }
 
@@ -286,9 +336,11 @@ class Slider_Translator {
         if (empty($schema_json) || $schema_json === '{}' || $schema_json === 'null') {
             return null;
         }
+        $this->stats['schema_fetch_success'] = true;
 
         if (!empty($target_lang_code)) {
             $schema_json = $this->translate_schema_json($schema_json, $target_lang_code);
+            $this->stats['schema_translated'] = true;
         }
 
         return $schema_json;

--- a/opio.php
+++ b/opio.php
@@ -3,7 +3,7 @@
 Plugin Name: Widget for OPIO Reviews
 Plugin URI: 
 Description: Instantly add OPIO Reviews on your website to increase user confidence and SEO.
-Version: 1.1.21
+Version: 1.1.22
 Author: Dhiraj Timalsina <dhiraj@n49.com>
 Text Domain: widget-for-opio-reviews
 Domain Path: /languages
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 
 require(ABSPATH . 'wp-includes/version.php');
 
-define('OPIO_PLUGIN_VERSION'   , '1.1.21');
+define('OPIO_PLUGIN_VERSION'   , '1.1.22');
 define('OPIO_PLUGIN_FILE'      , __FILE__);
 define('OPIO_PLUGIN_URL'       , plugins_url(basename(plugin_dir_path(__FILE__ )), basename(__FILE__)));
 define('OPIO_ASSETS_URL'       , OPIO_PLUGIN_URL . '/assets/');

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Author: Dhiraj Timalsina
 Tags: Widget for OPIO Reviews, opio, reviews, rating, widget, google business, testimonials
 Tested up to: 6.4
-Stable tag: 1.1.21
+Stable tag: 1.1.22
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -85,6 +85,10 @@ Any other ISO 639-1 code (e.g., `sw`, `nb`, `fi`, `cs`) will translate review co
 Full developer documentation, filter hooks for raising translation quota, and instructions for adding a 31st hand-curated language are in `LANGUAGES.md` in the plugin folder.
 
 == Changelog ==
+
+= 1.1.22 =
+* Add translation telemetry. Browser console now logs `[OPIO slider stats]` after each render with counters: `translation_calls`, `cache_full_hits`, `chunk_cache_hits`, `chunks_total`, `api_calls`, `api_success`, `api_errors`, `last_error`, `last_http_code`, `last_endpoint_host`, `schema_fetched`, `schema_fetch_success`, `schema_translated`. Lets you diagnose translation failures (rate limits, network blocks, API errors) from the browser without server access.
+* Server-side `error_log` lines for translation failures now include the target language code and endpoint host for easier grepping.
 
 = 1.1.21 =
 * Fix: slider tiles invisible on RTL host pages (Arabic / Persian / Urdu / Hebrew). The slider's outer wrapper now declares `direction: ltr` so page-level RTL inheritance doesn't break Slick carousel's internal positioning math. Arabic/Persian/Urdu/Hebrew text inside tiles still renders right-to-left via Unicode bidi.


### PR DESCRIPTION
Every render now logs a `[OPIO slider stats]` entry to the browser console with per-request counters. Lets the user diagnose translation failures (rate limits, network blocks, API errors) from devtools without needing server access.

Counters tracked in Slider_Translator:
- translation_calls    — translate_review_content() invocations
- cache_full_hits      — full-review cache served from transient
- chunks_total         — chunks the chunker produced
- chunk_cache_hits     — per-chunk cache hits
- api_calls            — outbound MyMemory requests made
- api_success          — successful translations
- api_errors           — failures of any kind
- last_error           — most recent failure (truncated 200 chars)
- last_http_code       — most recent HTTP response code
- last_endpoint_host   — host we attempted to call
- schema_fetched       — bool, did we attempt the op.io schema fetch
- schema_fetch_success — bool, did it return valid JSON
- schema_translated    — bool, did we run translation over schema

Server-side error_log lines for translation failures now include target lang code and endpoint host for easier grepping.

The pre-render debug script (`[OPIO slider]`) is still emitted first and now also includes `plugin_version`. The post-render stats script (`[OPIO slider stats]`) is emitted after the templates run so counters reflect the actual rendering pass.