### PR TITLE
add MyMemory circuit breaker + compact widget CSS (v1.1.23)

### DIFF
--- a/includes/class-slider-shortcode.php
+++ b/includes/class-slider-shortcode.php
@@ -83,6 +83,39 @@ class Slider_Shortcode {
             echo '<script type="text/javascript" id="opio-slider-i18n">window.opioSliderI18nActive = ' . wp_json_encode($js_translations) . ';</script>';
         }
 
+        // Compact CSS for the rating widget area. Translated strings (especially
+        // "Powered by" → "Con tecnología de" / "Bereitgestellt von" /
+        // "Pinapatakbo ng") are much longer than English and wrap across the
+        // narrow widget column. Shrink the font and force nowrap on the worst
+        // offenders so longer translations stay inline.
+        if (!empty($opio_target_lang)) {
+            echo '<style id="opio-slider-compact-css">'
+                . '#opio-horizontal-widget .rating-widget-part,'
+                . '#opio-carousel-widget .c-rating-widget-container,'
+                . '#opio-vertical-widget .v-rating-widget-container {'
+                . ' font-size: 12px;'
+                . '}'
+                . '#opio-horizontal-widget .w-pwd-text,'
+                . '#opio-carousel-widget .c-pwd-span,'
+                . '#opio-vertical-widget .v-pwd-span {'
+                . ' font-size: 10px;'
+                . ' white-space: nowrap;'
+                . '}'
+                . '#opio-horizontal-widget .see-all-text a,'
+                . '#opio-carousel-widget .c-see-all-div a,'
+                . '#opio-vertical-widget .v-see-all-span a {'
+                . ' font-size: 11px;'
+                . ' white-space: nowrap;'
+                . '}'
+                . '#opio-horizontal-widget .write-review-text span,'
+                . '#opio-carousel-widget .c-write-rev-inner-div span,'
+                . '#opio-vertical-widget .v-write-rev-div span {'
+                . ' font-size: 12px;'
+                . ' white-space: nowrap;'
+                . '}'
+                . '</style>';
+        }
+
         if($slider_type == 'horizontal') {
             include_once 'reviews-slider-horizontal-template.php';
         } else if($slider_type == 'horizontal-carousel') {

--- a/includes/class-slider-translator.php
+++ b/includes/class-slider-translator.php
@@ -4,9 +4,11 @@ namespace WP_Opio_Reviews\Includes;
 
 class Slider_Translator {
 
-    const TRANSIENT_PREFIX = 'opio_tr2_';
-    const TRANSIENT_TTL    = 2592000; // 30 days
-    const REQUEST_TIMEOUT  = 5;
+    const TRANSIENT_PREFIX        = 'opio_tr2_';
+    const TRANSIENT_TTL           = 2592000; // 30 days
+    const REQUEST_TIMEOUT         = 5;
+    const CIRCUIT_BREAKER_KEY     = 'opio_translation_rate_limited';
+    const CIRCUIT_BREAKER_SECONDS = 3600; // 1 hour
 
     private $stats = array(
         'translation_calls'   => 0,
@@ -16,21 +18,41 @@ class Slider_Translator {
         'api_calls'           => 0,
         'api_success'         => 0,
         'api_errors'          => 0,
+        'api_skipped'         => 0,
         'last_error'          => null,
         'last_http_code'      => null,
         'last_endpoint_host'  => null,
+        'email_filter'        => 'empty',
+        'circuit_breaker'     => null,
         'schema_fetched'      => false,
         'schema_fetch_success'=> false,
         'schema_translated'   => false,
     );
 
     public function get_stats() {
+        // Surface the live circuit-breaker state at read time so the debug log
+        // reflects exactly what was true during render.
+        $unblock_at = get_transient(self::CIRCUIT_BREAKER_KEY);
+        $this->stats['circuit_breaker'] = $unblock_at
+            ? ('blocked_until_' . (int) $unblock_at)
+            : null;
+        $this->stats['email_filter'] = empty(apply_filters('opio_translation_email', '')) ? 'empty' : 'set';
         return $this->stats;
     }
 
     private function record_error($message) {
         $this->stats['api_errors']++;
         $this->stats['last_error'] = is_string($message) ? substr($message, 0, 200) : 'unknown_error';
+    }
+
+    private function trip_circuit_breaker($reason) {
+        $unblock_at = time() + self::CIRCUIT_BREAKER_SECONDS;
+        set_transient(self::CIRCUIT_BREAKER_KEY, $unblock_at, self::CIRCUIT_BREAKER_SECONDS);
+        error_log('[OPIO slider] circuit breaker TRIPPED for ' . self::CIRCUIT_BREAKER_SECONDS . 's (reason: ' . $reason . '). Future translation requests will be skipped until ' . gmdate('Y-m-d H:i:s', $unblock_at) . ' UTC.');
+    }
+
+    private function is_circuit_breaker_open() {
+        return (bool) get_transient(self::CIRCUIT_BREAKER_KEY);
     }
 
     private static $locale_map = array(
@@ -184,6 +206,14 @@ class Slider_Translator {
             return $cached;
         }
 
+        // Circuit breaker: if we recently hit a rate-limit or quota cap, skip
+        // the API entirely and let the caller fall back to original text. This
+        // prevents 23+ doomed requests per render burning quota for nothing.
+        if ($this->is_circuit_breaker_open()) {
+            $this->stats['api_skipped']++;
+            return false;
+        }
+
         $endpoint = apply_filters('opio_translation_endpoint', 'https://api.mymemory.translated.net/get');
         $email    = apply_filters('opio_translation_email', '');
         $this->stats['last_endpoint_host'] = parse_url($endpoint, PHP_URL_HOST);
@@ -215,6 +245,9 @@ class Slider_Translator {
         if ($http_code !== 200) {
             $this->record_error('http_' . $http_code);
             error_log('[OPIO slider] translation HTTP ' . $http_code . ' (lang=' . $target_lang_code . ', host=' . $this->stats['last_endpoint_host'] . ')');
+            if ($http_code === 429 || $http_code === 503) {
+                $this->trip_circuit_breaker('http_' . $http_code);
+            }
             return false;
         }
 
@@ -232,6 +265,9 @@ class Slider_Translator {
             || stripos($translated, 'INVALID LANGUAGE PAIR') !== false) {
             $this->record_error('api_warning: ' . substr($translated, 0, 100));
             error_log('[OPIO slider] translation API warning (lang=' . $target_lang_code . '): ' . $translated);
+            if (stripos($translated, 'MYMEMORY WARNING') !== false) {
+                $this->trip_circuit_breaker('mymemory_quota_warning');
+            }
             return false;
         }
 

--- a/opio.php
+++ b/opio.php
@@ -3,7 +3,7 @@
 Plugin Name: Widget for OPIO Reviews
 Plugin URI: 
 Description: Instantly add OPIO Reviews on your website to increase user confidence and SEO.
-Version: 1.1.22
+Version: 1.1.23
 Author: Dhiraj Timalsina <dhiraj@n49.com>
 Text Domain: widget-for-opio-reviews
 Domain Path: /languages
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 
 require(ABSPATH . 'wp-includes/version.php');
 
-define('OPIO_PLUGIN_VERSION'   , '1.1.22');
+define('OPIO_PLUGIN_VERSION'   , '1.1.23');
 define('OPIO_PLUGIN_FILE'      , __FILE__);
 define('OPIO_PLUGIN_URL'       , plugins_url(basename(plugin_dir_path(__FILE__ )), basename(__FILE__)));
 define('OPIO_ASSETS_URL'       , OPIO_PLUGIN_URL . '/assets/');

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Author: Dhiraj Timalsina
 Tags: Widget for OPIO Reviews, opio, reviews, rating, widget, google business, testimonials
 Tested up to: 6.4
-Stable tag: 1.1.22
+Stable tag: 1.1.23
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -85,6 +85,11 @@ Any other ISO 639-1 code (e.g., `sw`, `nb`, `fi`, `cs`) will translate review co
 Full developer documentation, filter hooks for raising translation quota, and instructions for adding a 31st hand-curated language are in `LANGUAGES.md` in the plugin folder.
 
 == Changelog ==
+
+= 1.1.23 =
+* Add MyMemory circuit breaker. On `HTTP 429`, `HTTP 503`, or a `MYMEMORY WARNING` payload, sets a 1-hour transient (`opio_translation_rate_limited`) that short-circuits subsequent API calls. Stops the slider from firing 23+ doomed requests per render and burning more quota when the limit eventually resets. Counter `api_skipped` and field `circuit_breaker` in the stats log reflect the live state.
+* Add `email_filter` indicator to the translation stats so you can confirm whether the `opio_translation_email` filter actually loaded ("set" or "empty").
+* Compact CSS for the rating widget area when a `lang` attribute is active — shorter font sizes and `white-space: nowrap` on "Powered by" / "See all X Reviews" / "Write a review" so longer translated strings (Spanish "Con tecnología de", German "Bereitgestellt von", Tagalog "Pinapatakbo ng", etc.) don't wrap across multiple lines or get cut off.
 
 = 1.1.22 =
 * Add translation telemetry. Browser console now logs `[OPIO slider stats]` after each render with counters: `translation_calls`, `cache_full_hits`, `chunk_cache_hits`, `chunks_total`, `api_calls`, `api_success`, `api_errors`, `last_error`, `last_http_code`, `last_endpoint_host`, `schema_fetched`, `schema_fetch_success`, `schema_translated`. Lets you diagnose translation failures (rate limits, network blocks, API errors) from the browser without server access.


### PR DESCRIPTION
Two production issues addressed:

1. Circuit breaker for MyMemory rate-limit (HTTP 429 / 503 / WARNING payload). Once tripped, a 1-hour transient `opio_translation_rate_limited` short- circuits all subsequent translate_chunk() calls so the slider stops firing 23+ doomed API requests per render. Self-heals after the cooldown. New `api_skipped` counter and `circuit_breaker` field expose the live state in the browser-console stats log.

2. Compact CSS for the rating widget area when a `lang` attribute is set. Spanish "Con tecnología de", German "Bereitgestellt von", Tagalog "Pinapatakbo ng" etc. are much longer than English "Powered by" and were wrapping across multiple lines in the narrow widget column. Smaller font sizes + `white-space: nowrap` on "Powered by" / "See all X" / "Write a review" across all three layouts.

Also added `email_filter` field to stats log so you can confirm whether the `opio_translation_email` filter actually loaded.