### PR TITLE
auto-clear translation rate-limit breaker on plugin version change (v…

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -83,7 +83,16 @@ final class Plugin {
              }
 
     public function register_services() {
-  
+
+        // On plugin version change, clear the translation rate-limit circuit
+        // breaker so a fresh deploy can attempt MyMemory again immediately.
+        // If the rate limit is still active, the breaker re-trips on the next
+        // 429; if quota has reset, translations resume normally.
+        if (get_option('opio_translation_cache_version') !== OPIO_PLUGIN_VERSION) {
+            delete_transient(Slider_Translator::CIRCUIT_BREAKER_KEY);
+            update_option('opio_translation_cache_version', OPIO_PLUGIN_VERSION);
+        }
+
         $assets = new Assets(OPIO_ASSETS_URL, $this->version, get_option('opio_debug_mode') == '1');
         $assets->register();
 

--- a/opio.php
+++ b/opio.php
@@ -3,7 +3,7 @@
 Plugin Name: Widget for OPIO Reviews
 Plugin URI: 
 Description: Instantly add OPIO Reviews on your website to increase user confidence and SEO.
-Version: 1.1.23
+Version: 1.1.24
 Author: Dhiraj Timalsina <dhiraj@n49.com>
 Text Domain: widget-for-opio-reviews
 Domain Path: /languages
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 
 require(ABSPATH . 'wp-includes/version.php');
 
-define('OPIO_PLUGIN_VERSION'   , '1.1.23');
+define('OPIO_PLUGIN_VERSION'   , '1.1.24');
 define('OPIO_PLUGIN_FILE'      , __FILE__);
 define('OPIO_PLUGIN_URL'       , plugins_url(basename(plugin_dir_path(__FILE__ )), basename(__FILE__)));
 define('OPIO_ASSETS_URL'       , OPIO_PLUGIN_URL . '/assets/');

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Author: Dhiraj Timalsina
 Tags: Widget for OPIO Reviews, opio, reviews, rating, widget, google business, testimonials
 Tested up to: 6.4
-Stable tag: 1.1.23
+Stable tag: 1.1.24
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -85,6 +85,9 @@ Any other ISO 639-1 code (e.g., `sw`, `nb`, `fi`, `cs`) will translate review co
 Full developer documentation, filter hooks for raising translation quota, and instructions for adding a 31st hand-curated language are in `LANGUAGES.md` in the plugin folder.
 
 == Changelog ==
+
+= 1.1.24 =
+* Auto-clear the translation rate-limit circuit breaker on every plugin version change. Each deploy gets a fresh chance to reach MyMemory; if quota is still exhausted, the breaker re-trips automatically on the next 429.
 
 = 1.1.23 =
 * Add MyMemory circuit breaker. On `HTTP 429`, `HTTP 503`, or a `MYMEMORY WARNING` payload, sets a 1-hour transient (`opio_translation_rate_limited`) that short-circuits subsequent API calls. Stops the slider from firing 23+ doomed requests per render and burning more quota when the limit eventually resets. Counter `api_skipped` and field `circuit_breaker` in the stats log reflect the live state.


### PR DESCRIPTION
…1.1.24)

When OPIO_PLUGIN_VERSION differs from the last-seen value cached in the `opio_translation_cache_version` option, the plugin deletes the `opio_translation_rate_limited` transient on the first request that hits `Plugin::register_services()` after deploy.

Result: every plugin update is also a "force translation retry" lever — no need to install Transients Manager or run code snippets to manually clear the breaker. If MyMemory is still rate-limiting, the next 429 simply re-trips the breaker for another 60 minutes, so the protective behaviour from v1.1.23 is preserved.