### PR TITLE
Remove duplicate JSON-LD schema block from slider templates (v1.1.26)

### DIFF
--- a/includes/reviews-slider-horizontal-carousel-template.php
+++ b/includes/reviews-slider-horizontal-carousel-template.php
@@ -588,28 +588,6 @@ if ($opio_translator) {
     <?php } ?>
 </style>
 
-<?php if(isset($feed_object->schema_enabled) && $feed_object->schema_enabled == 'yes') {
-    $schema_url = 'https://op.io/review-schema.json/?entid=' . $feed_object->biz_id;
-    if($review_type === 'orgfeed') {
-        $schema_url = 'https://op.io/review-schema.json/?orgid=' . $feed_object->org_id;
-    }
-    if(isset($feed_object->schema_type) && $feed_object->schema_type == 'local') {
-        $schema_url .= '&type=local';
-    }
-    $schema_response = wp_remote_get($schema_url, ['timeout' => 5]);
-    if(!is_wp_error($schema_response) && $schema_response['response']['code'] === 200) {
-        $schema_json = $schema_response['body'];
-        if(!empty($schema_json) && $schema_json !== '{}' && $schema_json !== 'null') {
-?>
-<!-- JSON schema from op.io API -->
-<script type="application/ld+json">
-<?php echo $schema_json; ?>
-</script>
-<?php
-        }
-    }
-} ?>
-
 </div>
 
 <?php 

--- a/includes/reviews-slider-vertical-template.php
+++ b/includes/reviews-slider-vertical-template.php
@@ -377,28 +377,6 @@ if ($opio_translator) {
     }
 </style>
 
-<?php if(isset($feed_object->schema_enabled) && $feed_object->schema_enabled == 'yes') {
-    $schema_url = 'https://op.io/review-schema.json/?entid=' . $feed_object->biz_id;
-    if($review_type === 'orgfeed') {
-        $schema_url = 'https://op.io/review-schema.json/?orgid=' . $feed_object->org_id;
-    }
-    if(isset($feed_object->schema_type) && $feed_object->schema_type == 'local') {
-        $schema_url .= '&type=local';
-    }
-    $schema_response = wp_remote_get($schema_url, ['timeout' => 5]);
-    if(!is_wp_error($schema_response) && $schema_response['response']['code'] === 200) {
-        $schema_json = $schema_response['body'];
-        if(!empty($schema_json) && $schema_json !== '{}' && $schema_json !== 'null') {
-?>
-<!-- JSON schema from op.io API -->
-<script type="application/ld+json">
-<?php echo $schema_json; ?>
-</script>
-<?php
-        }
-    }
-} ?>
-
 </div>
 
 <?php 

--- a/opio.php
+++ b/opio.php
@@ -3,7 +3,7 @@
 Plugin Name: Widget for OPIO Reviews
 Plugin URI: 
 Description: Instantly add OPIO Reviews on your website to increase user confidence and SEO.
-Version: 1.1.25
+Version: 1.1.26
 Author: Dhiraj Timalsina <dhiraj@n49.com>
 Text Domain: widget-for-opio-reviews
 Domain Path: /languages
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 
 require(ABSPATH . 'wp-includes/version.php');
 
-define('OPIO_PLUGIN_VERSION'   , '1.1.25');
+define('OPIO_PLUGIN_VERSION'   , '1.1.26');
 define('OPIO_PLUGIN_FILE'      , __FILE__);
 define('OPIO_PLUGIN_URL'       , plugins_url(basename(plugin_dir_path(__FILE__ )), basename(__FILE__)));
 define('OPIO_ASSETS_URL'       , OPIO_PLUGIN_URL . '/assets/');

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Author: Dhiraj Timalsina
 Tags: Widget for OPIO Reviews, opio, reviews, rating, widget, google business, testimonials
 Tested up to: 6.4
-Stable tag: 1.1.25
+Stable tag: 1.1.26
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
The vertical and horizontal-carousel templates were emitting two <script type="application/ld+json"> blocks: one legacy block fetching the raw schema in English, and one new block from
Slider_Translator::fetch_and_translate_schema() which optionally translates the same payload. On translated pages this surfaced as visibly duplicated schema (English + translated) and on English pages it was a silent duplicate of identical JSON.

The translator path covers both cases: it fetches the same op.io/review-schema.json endpoint with the same parameters and only translates when a target language is present. Drop the legacy block from both templates so each render emits exactly one OPIO schema.