### PR TITLE
slider: hide unavailable review media images (v1.1.33)

### DIFF
--- a/assets/js/opio-slider-main.js
+++ b/assets/js/opio-slider-main.js
@@ -1,3 +1,35 @@
+// Hide review media images that fail to load (e.g. expired/removed Google review photos) so they
+// don't render as broken/blank tiles. A capture-phase 'error' listener catches every .review-img
+// failure — including slick-cloned slides and async-built nodes — and the DOM-ready sweep handles
+// images that already errored before this script ran. Collapses the gallery if it empties.
+(function () {
+    function opioHideBrokenReviewImg(img) {
+        if (!img || img.getAttribute('data-opio-hidden') === '1') return;
+        img.setAttribute('data-opio-hidden', '1');
+        var gallery = img.closest ? img.closest('.review-media-images') : null;
+        var cell = img.parentNode;
+        if (cell && cell.parentNode) { cell.parentNode.removeChild(cell); }
+        else { img.style.display = 'none'; }
+        if (gallery && !gallery.querySelector('img.review-img, .video-icon')) {
+            gallery.style.display = 'none';
+        }
+    }
+    if (typeof document !== 'undefined') {
+        document.addEventListener('error', function (e) {
+            var t = e && e.target;
+            if (t && t.tagName === 'IMG' && (' ' + (t.className || '') + ' ').indexOf(' review-img ') !== -1) {
+                opioHideBrokenReviewImg(t);
+            }
+        }, true);
+        document.addEventListener('DOMContentLoaded', function () {
+            var imgs = document.querySelectorAll('img.review-img');
+            for (var i = 0; i < imgs.length; i++) {
+                if (imgs[i].complete && imgs[i].naturalWidth === 0) { opioHideBrokenReviewImg(imgs[i]); }
+            }
+        });
+    }
+})();
+
 function opioI18n(s) {
     var hasMap = (typeof window !== 'undefined' && !!window.opioSliderI18nActive);
     var hit = hasMap && Object.prototype.hasOwnProperty.call(window.opioSliderI18nActive, s);

--- a/opio.php
+++ b/opio.php
@@ -3,7 +3,7 @@
 Plugin Name: Widget for OPIO Reviews
 Plugin URI: 
 Description: Instantly add OPIO Reviews on your website to increase user confidence and SEO.
-Version: 1.1.32
+Version: 1.1.33
 Author: Dhiraj Timalsina <dhiraj@n49.com>
 Text Domain: widget-for-opio-reviews
 Domain Path: /languages
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 
 require(ABSPATH . 'wp-includes/version.php');
 
-define('OPIO_PLUGIN_VERSION'   , '1.1.32');
+define('OPIO_PLUGIN_VERSION'   , '1.1.33');
 define('OPIO_PLUGIN_FILE'      , __FILE__);
 define('OPIO_PLUGIN_URL'       , plugins_url(basename(plugin_dir_path(__FILE__ )), basename(__FILE__)));
 define('OPIO_ASSETS_URL'       , OPIO_PLUGIN_URL . '/assets/');

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Author: Dhiraj Timalsina
 Tags: Widget for OPIO Reviews, opio, reviews, rating, widget, google business, testimonials
 Tested up to: 6.4
-Stable tag: 1.1.32
+Stable tag: 1.1.33
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -85,6 +85,9 @@ Any other ISO 639-1 code (e.g., `sw`, `nb`, `fi`, `cs`) will translate review co
 Full developer documentation, filter hooks for raising translation quota, and instructions for adding a 31st hand-curated language are in `LANGUAGES.md` in the plugin folder.
 
 == Changelog ==
+
+= 1.1.33 =
+* Slider: hide review media images that fail to load (e.g. expired or removed Google review photos) instead of rendering broken/blank tiles. A delegated error handler also covers carousel-cloned slides, and the media gallery collapses if no images remain.
 
 = 1.1.32 =
 * Slider: support Google reviews with photos and videos. Google media carries direct URLs (`thumbnailUrl`/`url`) instead of opio image/video IDs, so the slider now renders these directly. Google videos play inside a no-referrer iframe to bypass Google's cross-site hotlink protection.


### PR DESCRIPTION
Delegated capture-phase error handler in opio-slider-main.js hides any .review-img that fails to load (e.g. expired/removed Google photos), covers slick-cloned slides, sweeps already-broken images on load, and collapses the gallery if it empties. Bump version 1.1.32 -> 1.1.33.