### PR TITLE
Load assets only on pages using an OPIO shortcode (v1.1.34)

### DIFF
--- a/includes/class-assets.php
+++ b/includes/class-assets.php
@@ -25,6 +25,11 @@ class Assets {
         'opio-slider-main-js'    => 'js/opio-slider-main',
     );
 
+    // Shortcode tags whose presence on a page means the public bundle is needed.
+    private static $shortcode_tags = array(
+        'opio_slider', 'opio_feed', 'opio_feed_optimized', 'opio_feed_french',
+    );
+
     public function __construct($url, $version, $debug) {
         $this->url     = $url;
         $this->version = $version;
@@ -38,22 +43,33 @@ class Assets {
         add_action('admin_enqueue_scripts', array($this, 'enqueue_admin_scripts'));
         add_action('wp_enqueue_scripts', array($this, 'register_styles'));
         add_action('wp_enqueue_scripts', array($this, 'register_scripts'));
+        // Frontend: only load the bundle when a page actually uses an OPIO
+        // shortcode. The plugin's Slick build registers jQuery.fn.slick
+        // globally; loading it everywhere overwrites the theme's own Slick and
+        // breaks unrelated theme sliders (see craft-bilt product galleries).
+        add_action('wp_enqueue_scripts', array($this, 'maybe_enqueue_public_assets'));
+        // Render-time fallback for shortcodes placed outside post_content
+        // (widgets, page builders, do_shortcode in templates). Enqueues late;
+        // scripts/styles print in the footer.
+        add_action('opio_enqueue_assets', array($this, 'enqueue_public_assets'));
 
         // load Roboto font from fonts fonts/roboto.css
     }
 
     public function register_styles() {
-        $styles = array('opio-admin-main-css', 'opio-public-main-css', 'opio-feed-css', 'opio-slick-theme-css', 'opio-slick-min-css');
-        $this->register_styles_loop($styles);
-        wp_enqueue_style('roboto-font', $this->url . 'fonts/roboto.css', array(), $this->version);    
+        $this->register_styles_loop(array_keys(self::$css_assets));
+        wp_register_style('roboto-font', $this->url . 'fonts/roboto.css', array(), $this->version);
+        // Admin loads the full bundle unconditionally (preview rendering).
+        if (is_admin()) {
+            $this->enqueue_public_styles();
+        }
     }
 
     public function register_scripts() {
-        $scripts = array('opio-main-js', 'moment-opio-js', 'slick-opio-carousel-js', 'opio-slider-main-js');
-        if (!wp_script_is('jquery', 'enqueued')) {
-            $scripts = array('opio-main-js', 'moment-opio-js', 'jQuery-opio-3.6.0-js', 'slick-opio-carousel-js', 'opio-slider-main-js');
+        $this->register_scripts_loop(array_keys(self::$js_assets));
+        if (is_admin()) {
+            $this->enqueue_public_scripts();
         }
-        $this->register_scripts_loop($scripts);
     }
 
     public function enqueue_admin_styles() {
@@ -75,18 +91,65 @@ class Assets {
         wp_enqueue_script('opio-main-js');
 
     }
-    
+
+    // Enqueue the public bundle when the queried post contains an OPIO
+    // shortcode. Runs on wp_enqueue_scripts so assets land in <head>.
+    public function maybe_enqueue_public_assets() {
+        if ($this->current_page_has_opio_shortcode()) {
+            $this->enqueue_public_assets();
+        }
+    }
+
+    public function enqueue_public_assets() {
+        $this->enqueue_public_styles();
+        $this->enqueue_public_scripts();
+    }
+
+    private function enqueue_public_styles() {
+        $styles = array(
+            'opio-admin-main-css', 'opio-public-main-css', 'opio-feed-css',
+            'opio-slick-theme-css', 'opio-slick-min-css', 'roboto-font',
+        );
+        foreach ($styles as $style) {
+            wp_enqueue_style($style);
+        }
+    }
+
+    private function enqueue_public_scripts() {
+        $scripts = array('opio-main-js', 'moment-opio-js', 'slick-opio-carousel-js', 'opio-slider-main-js');
+        if (!wp_script_is('jquery', 'enqueued')) {
+            array_unshift($scripts, 'jQuery-opio-3.6.0-js');
+        }
+        foreach ($scripts as $script) {
+            wp_enqueue_script($script);
+        }
+    }
+
+    private function current_page_has_opio_shortcode() {
+        if (is_admin()) {
+            return false;
+        }
+        global $post;
+        if (!($post instanceof \WP_Post)) {
+            return false;
+        }
+        foreach (self::$shortcode_tags as $tag) {
+            if (has_shortcode($post->post_content, $tag)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private function register_styles_loop($styles) {
         foreach ($styles as $style) {
             wp_register_style($style, $this->get_css_asset($style), array(), $this->version);
-            wp_enqueue_style($style);
         }
     }
 
     private function register_scripts_loop($scripts) {
         foreach ($scripts as $script) {
             wp_register_script($script, $this->get_js_asset($script), array(), $this->version);
-            wp_enqueue_script($script);
         }
     }
 

--- a/includes/class-feed-french-shortcode.php
+++ b/includes/class-feed-french-shortcode.php
@@ -44,6 +44,7 @@ class Feed_French_Shortcode {
         if (get_option('opio_active') === '0') {
             return '';
         }
+        do_action('opio_enqueue_assets');
 
         $feed = $this->feed_deserializer->get_feed($atts['id']);
         if ($feed == null) {

--- a/includes/class-feed-optimized-shortcode.php
+++ b/includes/class-feed-optimized-shortcode.php
@@ -68,6 +68,7 @@ class Feed_Optimized_Shortcode {
         if (get_option('opio_active') === '0') {
             return '';
         }
+        do_action('opio_enqueue_assets');
 
         $feed = $this->feed_deserializer->get_feed($atts['id']);
         if ($feed == null) {

--- a/includes/class-feed-shortcode.php
+++ b/includes/class-feed-shortcode.php
@@ -369,6 +369,7 @@ class Feed_Shortcode {
         if (get_option('opio_active') === '0') {
             return '';
         }
+        do_action('opio_enqueue_assets');
         ob_start();
         $feed = $this->feed_deserializer->get_feed($atts['id']);
         $feed_id = '';

--- a/includes/class-slider-shortcode.php
+++ b/includes/class-slider-shortcode.php
@@ -58,6 +58,7 @@ class Slider_Shortcode {
         if (get_option('opio_active') === '0') {
             return '';
         }
+        do_action('opio_enqueue_assets');
         $feed = $this->slider_deserializer->get_feed($atts['id']);
         $feed_id = '';
         $loaded_bizs = '';

--- a/opio.php
+++ b/opio.php
@@ -3,7 +3,7 @@
 Plugin Name: Widget for OPIO Reviews
 Plugin URI: 
 Description: Instantly add OPIO Reviews on your website to increase user confidence and SEO.
-Version: 1.1.33
+Version: 1.1.34
 Author: Dhiraj Timalsina <dhiraj@n49.com>
 Text Domain: widget-for-opio-reviews
 Domain Path: /languages
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 
 require(ABSPATH . 'wp-includes/version.php');
 
-define('OPIO_PLUGIN_VERSION'   , '1.1.33');
+define('OPIO_PLUGIN_VERSION'   , '1.1.34');
 define('OPIO_PLUGIN_FILE'      , __FILE__);
 define('OPIO_PLUGIN_URL'       , plugins_url(basename(plugin_dir_path(__FILE__ )), basename(__FILE__)));
 define('OPIO_ASSETS_URL'       , OPIO_PLUGIN_URL . '/assets/');

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Author: Dhiraj Timalsina
 Tags: Widget for OPIO Reviews, opio, reviews, rating, widget, google business, testimonials
 Tested up to: 6.4
-Stable tag: 1.1.33
+Stable tag: 1.1.34
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -85,6 +85,9 @@ Any other ISO 639-1 code (e.g., `sw`, `nb`, `fi`, `cs`) will translate review co
 Full developer documentation, filter hooks for raising translation quota, and instructions for adding a 31st hand-curated language are in `LANGUAGES.md` in the plugin folder.
 
 == Changelog ==
+
+= 1.1.34 =
+* Fix: only load the plugin's CSS/JS (including its bundled Slick carousel) on pages that actually use an OPIO shortcode. Previously the bundle loaded site-wide and its global jQuery.fn.slick overwrote the active theme's own Slick build, breaking unrelated theme sliders/galleries.
 
 = 1.1.33 =
 * Slider: hide review media images that fail to load (e.g. expired or removed Google review photos) instead of rendering broken/blank tiles. A delegated error handler also covers carousel-cloned slides, and the media gallery collapses if no images remain.


### PR DESCRIPTION
The plugin enqueued its bundled Slick build site-wide, overwriting the active theme's global jQuery.fn.slick and breaking unrelated theme sliders (e.g. craft-bilt product galleries throwing getNavigableIndexes RangeError / asNavFor getSlick errors).

Frontend assets now register on wp_enqueue_scripts but only enqueue when the queried post contains an opio_slider/opio_feed/opio_feed_optimized/ opio_feed_french shortcode. A render-time do_action('opio_enqueue_assets') fallback covers widget/page-builder placements (footer load). Admin behavior is unchanged.