### PR TITLE
Fix slider CSS missing on widget/page-builder placements (v1.1.37)

### DIFF
--- a/includes/class-assets.php
+++ b/includes/class-assets.php
@@ -120,6 +120,17 @@ class Assets {
         foreach ($styles as $style) {
             wp_enqueue_style($style);
         }
+        // Render-time fallback (widget / page-builder / template do_shortcode)
+        // fires after wp_head has already printed. These are head-group styles,
+        // so WordPress' footer late-style pass skips them -> the slider loads
+        // unstyled (scripts still print in the footer, so Slick initializes but
+        // there is no layout CSS and every slide stacks vertically). When we're
+        // already past wp_head, emit the <link> tags inline at the render point.
+        // wp_print_styles() marks them done, so the head/footer passes won't
+        // double-print, and <link> inside <body> is valid HTML5.
+        if (did_action('wp_head')) {
+            wp_print_styles($styles);
+        }
     }
 
     private function enqueue_public_scripts() {

--- a/opio.php
+++ b/opio.php
@@ -3,7 +3,7 @@
 Plugin Name: Widget for OPIO Reviews
 Plugin URI: 
 Description: Instantly add OPIO Reviews on your website to increase user confidence and SEO.
-Version: 1.1.36
+Version: 1.1.37
 Author: Dhiraj Timalsina <dhiraj@n49.com>
 Text Domain: widget-for-opio-reviews
 Domain Path: /languages
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 
 require(ABSPATH . 'wp-includes/version.php');
 
-define('OPIO_PLUGIN_VERSION'   , '1.1.36');
+define('OPIO_PLUGIN_VERSION'   , '1.1.37');
 define('OPIO_PLUGIN_FILE'      , __FILE__);
 define('OPIO_PLUGIN_URL'       , plugins_url(basename(plugin_dir_path(__FILE__ )), basename(__FILE__)));
 define('OPIO_ASSETS_URL'       , OPIO_PLUGIN_URL . '/assets/');

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Author: Dhiraj Timalsina
 Tags: Widget for OPIO Reviews, opio, reviews, rating, widget, google business, testimonials
 Tested up to: 6.4
-Stable tag: 1.1.36
+Stable tag: 1.1.37
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -85,6 +85,12 @@ Any other ISO 639-1 code (e.g., `sw`, `nb`, `fi`, `cs`) will translate review co
 Full developer documentation, filter hooks for raising translation quota, and instructions for adding a 31st hand-curated language are in `LANGUAGES.md` in the plugin folder.
 
 == Changelog ==
+
+= 1.1.37 =
+* Fix: slider rendered unstyled (slides stacked in a tall column) when placed via a widget, page builder, or template do_shortcode. The render-time asset fallback runs after wp_head, so the plugin's stylesheets were skipped by WordPress' footer late-style pass while the scripts still loaded. The styles are now emitted inline at render time when past wp_head.
+
+= 1.1.36 =
+* Fix: isolate the plugin's bundled Slick onto a private jQuery instance (window.opioJQ via noConflict) and declare real jQuery dependencies, so slider init no longer depends on script ordering and never overwrites the theme's own jQuery/Slick.
 
 = 1.1.35 =
 * Maintenance re-release (no functional changes since 1.1.34) to ensure the update is delivered to existing installations.


### PR DESCRIPTION
The v1.1.34 conditional-loading change only detects OPIO shortcodes in $post->post_content. Widget / page-builder / template do_shortcode placements fall through to the render-time opio_enqueue_assets fallback, which fires after wp_head. WordPress still prints the scripts in the footer (Slick initializes), but the plugin's head-group stylesheets are skipped by the footer late-style pass -> the slider renders unstyled and every slide stacks into a tall column.

Fix: when enqueue_public_styles() runs after wp_head has printed, emit the <link> tags inline at the render point via wp_print_styles(). It marks the handles done so the head/footer passes never double-print, and <link> inside <body> is valid HTML5. No script or asset-scope changes: conditional loading and the v1.1.36 jQuery/Slick isolation are untouched.