### PR TITLE
Stop embed autoplay on first-media auto-load (v1.1.38)

### DIFF
--- a/assets/js/opio-main.js
+++ b/assets/js/opio-main.js
@@ -65,10 +65,10 @@ function displayEmbed(embed, revId) {
             var iframeHtml;
             if (isShort) {
                 var shortWidth = maxHeight * (9 / 16);
-                iframeHtml = '<div style="display: inline-block; width: ' + shortWidth + 'px; height: ' + maxHeight + 'px; margin: 5px; position: relative; background: #000; border-radius: 4px; overflow: hidden; vertical-align: top;"><iframe width="100%" height="100%" src="https://www.youtube.com/embed/' + videoId + '?autoplay=1&modestbranding=1&rel=0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen style="position: absolute; top: 0; left: 0;"></iframe></div>';
+                iframeHtml = '<div style="display: inline-block; width: ' + shortWidth + 'px; height: ' + maxHeight + 'px; margin: 5px; position: relative; background: #000; border-radius: 4px; overflow: hidden; vertical-align: top;"><iframe width="100%" height="100%" src="https://www.youtube.com/embed/' + videoId + '?modestbranding=1&rel=0" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen style="position: absolute; top: 0; left: 0;"></iframe></div>';
             } else {
                 var videoHeight = Math.min(containerWidth * 0.5625, maxHeight);
-                iframeHtml = '<div style="width: 98.5%; height: ' + videoHeight + 'px; margin: 5px; position: relative; background: #000; border-radius: 4px; overflow: hidden;"><iframe width="100%" height="100%" src="https://www.youtube.com/embed/' + videoId + '?autoplay=1&modestbranding=1&rel=0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen style="position: absolute; top: 0; left: 0;"></iframe></div>';
+                iframeHtml = '<div style="width: 98.5%; height: ' + videoHeight + 'px; margin: 5px; position: relative; background: #000; border-radius: 4px; overflow: hidden;"><iframe width="100%" height="100%" src="https://www.youtube.com/embed/' + videoId + '?modestbranding=1&rel=0" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen style="position: absolute; top: 0; left: 0;"></iframe></div>';
             }
             elem.innerHTML = iframeHtml;
         } else if (embed.url && typeof embed.url === 'string' && embed.url.trim()) {

--- a/assets/js/opio-slider-main.js
+++ b/assets/js/opio-slider-main.js
@@ -205,10 +205,10 @@ function displayEmbed(embed, revId) {
             var iframeHtml;
             if (isShort) {
                 var shortWidth = maxHeight * (9 / 16);
-                iframeHtml = '<div style="display: inline-block; width: ' + shortWidth + 'px; height: ' + maxHeight + 'px; margin: 5px; position: relative; background: #000; border-radius: 4px; overflow: hidden; vertical-align: top;"><iframe width="100%" height="100%" src="https://www.youtube.com/embed/' + videoId + '?autoplay=1&modestbranding=1&rel=0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen style="position: absolute; top: 0; left: 0;"></iframe></div>';
+                iframeHtml = '<div style="display: inline-block; width: ' + shortWidth + 'px; height: ' + maxHeight + 'px; margin: 5px; position: relative; background: #000; border-radius: 4px; overflow: hidden; vertical-align: top;"><iframe width="100%" height="100%" src="https://www.youtube.com/embed/' + videoId + '?modestbranding=1&rel=0" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen style="position: absolute; top: 0; left: 0;"></iframe></div>';
             } else {
                 var videoHeight = Math.min(containerWidth * 0.5625, maxHeight);
-                iframeHtml = '<div style="width: 100%; height: ' + videoHeight + 'px; margin: 5px 0; position: relative; background: #000; border-radius: 4px; overflow: hidden;"><iframe width="100%" height="100%" src="https://www.youtube.com/embed/' + videoId + '?autoplay=1&modestbranding=1&rel=0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen style="position: absolute; top: 0; left: 0;"></iframe></div>';
+                iframeHtml = '<div style="width: 100%; height: ' + videoHeight + 'px; margin: 5px 0; position: relative; background: #000; border-radius: 4px; overflow: hidden;"><iframe width="100%" height="100%" src="https://www.youtube.com/embed/' + videoId + '?modestbranding=1&rel=0" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen style="position: absolute; top: 0; left: 0;"></iframe></div>';
             }
             elem.innerHTML = iframeHtml;
         } else if (platform === 'tiktok') {
@@ -224,7 +224,7 @@ function displayEmbed(embed, revId) {
             var tiktokWidth = window.innerWidth < 768 ? Math.min(window.innerWidth * 0.985, 380) : 340;
             tiktokWidth = Math.max(tiktokWidth, 320);
             var tiktokHeight = window.innerWidth < 768 ? 700 : 740;
-            var tiktokHtml = '<div style="display: inline-block; width: ' + tiktokWidth + 'px; height: ' + tiktokHeight + 'px; margin: 5px auto; position: relative; background: #000; border-radius: 4px; overflow: hidden; vertical-align: top;"><iframe width="100%" height="100%" src="https://www.tiktok.com/embed/v2/' + tiktokVideoId + '" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen scrolling="no" style="position: absolute; top: 0; left: 0;"></iframe></div>';
+            var tiktokHtml = '<div style="display: inline-block; width: ' + tiktokWidth + 'px; height: ' + tiktokHeight + 'px; margin: 5px auto; position: relative; background: #000; border-radius: 4px; overflow: hidden; vertical-align: top;"><iframe width="100%" height="100%" src="https://www.tiktok.com/embed/v2/' + tiktokVideoId + '" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen scrolling="no" style="position: absolute; top: 0; left: 0;"></iframe></div>';
             elem.innerHTML = tiktokHtml;
         } else if (platform === 'instagram') {
             var igPostId = embed.postId || '';
@@ -241,7 +241,7 @@ function displayEmbed(embed, revId) {
             igWidth = Math.max(igWidth, 320);
             var igHeight = isReel ? (window.innerWidth < 768 ? 700 : 740) : (igWidth * 1.25 + 98);
             var igSrc = 'https://www.instagram.com/' + (isReel ? 'reel' : 'p') + '/' + igPostId + '/embed/?hidecaption=true';
-            var igHtml = '<div style="display: inline-block; width: ' + igWidth + 'px; height: ' + igHeight + 'px; margin: 5px auto; position: relative; background: #fafafa; border-radius: 4px; overflow: hidden; vertical-align: top;"><iframe width="100%" height="100%" src="' + igSrc + '" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen scrolling="no" style="position: absolute; top: 0; left: 0;"></iframe></div>';
+            var igHtml = '<div style="display: inline-block; width: ' + igWidth + 'px; height: ' + igHeight + 'px; margin: 5px auto; position: relative; background: #fafafa; border-radius: 4px; overflow: hidden; vertical-align: top;"><iframe width="100%" height="100%" src="' + igSrc + '" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen scrolling="no" style="position: absolute; top: 0; left: 0;"></iframe></div>';
             elem.innerHTML = igHtml;
         } else if (embed.url && typeof embed.url === 'string' && embed.url.trim()) {
             window.open(embed.url.trim(), '_blank');

--- a/opio.php
+++ b/opio.php
@@ -3,7 +3,7 @@
 Plugin Name: Widget for OPIO Reviews
 Plugin URI: 
 Description: Instantly add OPIO Reviews on your website to increase user confidence and SEO.
-Version: 1.1.37
+Version: 1.1.38
 Author: Dhiraj Timalsina <dhiraj@n49.com>
 Text Domain: widget-for-opio-reviews
 Domain Path: /languages
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 
 require(ABSPATH . 'wp-includes/version.php');
 
-define('OPIO_PLUGIN_VERSION'   , '1.1.37');
+define('OPIO_PLUGIN_VERSION'   , '1.1.38');
 define('OPIO_PLUGIN_FILE'      , __FILE__);
 define('OPIO_PLUGIN_URL'       , plugins_url(basename(plugin_dir_path(__FILE__ )), basename(__FILE__)));
 define('OPIO_ASSETS_URL'       , OPIO_PLUGIN_URL . '/assets/');

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Author: Dhiraj Timalsina
 Tags: Widget for OPIO Reviews, opio, reviews, rating, widget, google business, testimonials
 Tested up to: 6.4
-Stable tag: 1.1.37
+Stable tag: 1.1.38
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -85,6 +85,9 @@ Any other ISO 639-1 code (e.g., `sw`, `nb`, `fi`, `cs`) will translate review co
 Full developer documentation, filter hooks for raising translation quota, and instructions for adding a 31st hand-curated language are in `LANGUAGES.md` in the plugin folder.
 
 == Changelog ==
+
+= 1.1.38 =
+* Fix: YouTube Shorts/videos and TikTok/Instagram embeds no longer autoplay when a review's first media auto-loads (e.g. after Load More in the slider). Removed the hardcoded autoplay=1 and the autoplay permission from embed iframes; playback now waits for an explicit user click.
 
 = 1.1.37 =
 * Fix: slider rendered unstyled (slides stacked in a tall column) when placed via a widget, page builder, or template do_shortcode. The render-time asset fallback runs after wp_head, so the plugin's stylesheets were skipped by WordPress' footer late-style pass while the scripts still loaded. The styles are now emitted inline at render time when past wp_head.


### PR DESCRIPTION
Remove hardcoded autoplay=1 and the autoplay permission from YouTube/ TikTok/Instagram embed iframes in opio-slider-main.js and opio-main.js. The slider auto-inits a review's first media; for embeds it was calling displayEmbed with autoplay=1, so a Short auto-played. Playback now waits for an explicit user click. Native-video click path unchanged.